### PR TITLE
feat(reviews) : 영화 리뷰기능 UI/UX 수정 및 백엔드 api 구현, 엔드포인트 재정의 및 FE 리뷰 로직 수정

### DIFF
--- a/server/controllers/reviewController.js
+++ b/server/controllers/reviewController.js
@@ -1,0 +1,307 @@
+const jwt = require("jsonwebtoken");
+
+// In-memory stores (demo purpose)
+let reviews = [];
+let reviewComments = [];
+
+// Helpers
+function getUserIdFromToken(req) {
+  const authHeader = req.headers["authorization"];
+  const token = authHeader?.split(" ")[1];
+  if (!token) return null;
+  try {
+    const decoded = jwt.verify(token, process.env.SECRET_KEY);
+    return decoded?.id || null;
+  } catch {
+    return null;
+  }
+}
+
+function uid() {
+  return `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function mapReview(r) {
+  return {
+    _id: r.id,
+    userId: r.userId,
+    movieId: r.movieId,
+    rating: r.rating,
+    content: r.content,
+    likes: r.likesBy?.length || 0,
+    dislikes: r.dislikesBy?.length || 0,
+    likedBy: r.likesBy || [],
+    dislikedBy: r.dislikesBy || [],
+    tags: r.tags || [],
+    isSpoiler: !!r.isSpoiler,
+    createdAt: r.createdAt,
+    updatedAt: r.updatedAt,
+  };
+}
+
+// Ensure reply attaches to root comment (instagram-like)
+function resolveRootParent(commentId) {
+  let current = reviewComments.find((c) => c.id === commentId) || null;
+  if (!current) return null;
+  while (current && current.parentId) {
+    current = reviewComments.find((c) => c.id === current.parentId) || null;
+  }
+  return current ? current.id : null;
+}
+
+// ===== Reviews =====
+exports.createReview = (req, res) => {
+  const userId = getUserIdFromToken(req);
+  if (!userId) return res.status(401).json({ message: "인증이 필요합니다." });
+  const { movieId, rating, content, tags = [], isSpoiler = false } = req.body || {};
+  if (!movieId || !rating || !content) return res.status(400).json({ message: "movieId, rating, content 필요" });
+
+  // unique constraint: one review per (userId, movieId)
+  const exists = reviews.find((r) => r.userId === userId && r.movieId === Number(movieId));
+  if (exists) return res.status(409).json({ message: "이미 해당 영화에 리뷰가 존재합니다." });
+
+  const now = new Date().toISOString();
+  const review = {
+    id: uid(),
+    userId,
+    movieId: Number(movieId),
+    rating: Math.max(1, Math.min(5, Number(rating))),
+    content: String(content),
+    tags: Array.isArray(tags) ? tags.slice(0, 20) : [],
+    isSpoiler: !!isSpoiler,
+    likesBy: [],
+    dislikesBy: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+  reviews.unshift(review);
+  return res.status(201).json(mapReview(review));
+};
+
+exports.getReviewsByMovie = (req, res) => {
+  const movieId = Number(req.params.movieId);
+  const page = Math.max(1, Number(req.query.page || 1));
+  const limit = Math.max(1, Math.min(50, Number(req.query.limit || 10)));
+  const sort = req.query.sort || "recent"; // recent|rating|helpful
+  const ratingFilter = Number(req.query.ratingFilter || 0); // 0 or 1..5
+  const hasSpoiler = req.query.hasSpoiler === "true" ? true : req.query.hasSpoiler === "false" ? false : undefined;
+
+  let list = reviews.filter((r) => r.movieId === movieId);
+  if (ratingFilter >= 1 && ratingFilter <= 5) list = list.filter((r) => r.rating === ratingFilter);
+  if (typeof hasSpoiler === "boolean") list = list.filter((r) => r.isSpoiler === hasSpoiler);
+
+  if (sort === "rating") list.sort((a, b) => b.rating - a.rating || new Date(b.createdAt) - new Date(a.createdAt));
+  else if (sort === "helpful") list.sort((a, b) => (b.likesBy.length - b.dislikesBy.length) - (a.likesBy.length - a.dislikesBy.length) || new Date(b.createdAt) - new Date(a.createdAt));
+  else list.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+
+  const total = list.length;
+  const start = (page - 1) * limit;
+  const items = list.slice(start, start + limit).map(mapReview);
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+  return res.json({ reviews: items, total, page, totalPages });
+};
+
+exports.getMovieStats = (req, res) => {
+  const movieId = Number(req.params.movieId);
+  const list = reviews.filter((r) => r.movieId === movieId);
+  const total = list.length;
+  const avg = total ? Number((list.reduce((s, r) => s + r.rating, 0) / total).toFixed(2)) : 0;
+  return res.json({ averageRating: avg, totalReviews: total });
+};
+
+exports.getMyReviews = (req, res) => {
+  const userId = getUserIdFromToken(req);
+  if (!userId) return res.status(401).json({ message: "인증이 필요합니다." });
+  const list = reviews
+    .filter((r) => r.userId === userId)
+    .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
+    .map(mapReview);
+  return res.json(list);
+};
+
+exports.getReviewById = (req, res) => {
+  const review = reviews.find((r) => r.id === req.params.reviewId);
+  if (!review) return res.status(404).json({ message: "리뷰를 찾을 수 없습니다." });
+  return res.json(mapReview(review));
+};
+
+exports.updateReview = (req, res) => {
+  const userId = getUserIdFromToken(req);
+  if (!userId) return res.status(401).json({ message: "인증이 필요합니다." });
+  const id = req.params.reviewId;
+  const idx = reviews.findIndex((r) => r.id === id);
+  if (idx === -1) return res.status(404).json({ message: "리뷰를 찾을 수 없습니다." });
+  if (reviews[idx].userId !== userId) return res.status(403).json({ message: "수정 권한이 없습니다." });
+  const { rating, content, tags, isSpoiler } = req.body || {};
+  if (rating != null) reviews[idx].rating = Math.max(1, Math.min(5, Number(rating)));
+  if (content != null) reviews[idx].content = String(content);
+  if (tags != null && Array.isArray(tags)) reviews[idx].tags = tags.slice(0, 20);
+  if (isSpoiler != null) reviews[idx].isSpoiler = !!isSpoiler;
+  reviews[idx].updatedAt = new Date().toISOString();
+  return res.json(mapReview(reviews[idx]));
+};
+
+exports.deleteReview = (req, res) => {
+  const userId = getUserIdFromToken(req);
+  if (!userId) return res.status(401).json({ message: "인증이 필요합니다." });
+  const id = req.params.reviewId;
+  const idx = reviews.findIndex((r) => r.id === id);
+  if (idx === -1) return res.status(404).json({ message: "리뷰를 찾을 수 없습니다." });
+  if (reviews[idx].userId !== userId) return res.status(403).json({ message: "삭제 권한이 없습니다." });
+  // remove comments under this review as well
+  reviewComments = reviewComments.filter((c) => c.reviewId !== id);
+  const removed = reviews.splice(idx, 1)[0];
+  return res.json({ message: "리뷰가 삭제되었습니다.", id: removed.id });
+};
+
+exports.likeReview = (req, res) => {
+  const userId = getUserIdFromToken(req);
+  if (!userId) return res.status(401).json({ message: "인증이 필요합니다." });
+  const id = req.params.reviewId;
+  const r = reviews.find((x) => x.id === id);
+  if (!r) return res.status(404).json({ message: "리뷰를 찾을 수 없습니다." });
+  const liked = r.likesBy.includes(userId);
+  // toggle like
+  if (liked) r.likesBy = r.likesBy.filter((u) => u !== userId);
+  else r.likesBy = [userId, ...r.likesBy];
+  // ensure dislike removed when like added
+  r.dislikesBy = r.dislikesBy.filter((u) => u !== userId);
+  return res.json(mapReview(r));
+};
+
+exports.dislikeReview = (req, res) => {
+  const userId = getUserIdFromToken(req);
+  if (!userId) return res.status(401).json({ message: "인증이 필요합니다." });
+  const id = req.params.reviewId;
+  const r = reviews.find((x) => x.id === id);
+  if (!r) return res.status(404).json({ message: "리뷰를 찾을 수 없습니다." });
+  const disliked = r.dislikesBy.includes(userId);
+  if (disliked) r.dislikesBy = r.dislikesBy.filter((u) => u !== userId);
+  else r.dislikesBy = [userId, ...r.dislikesBy];
+  r.likesBy = r.likesBy.filter((u) => u !== userId);
+  return res.json(mapReview(r));
+};
+
+exports.getReactionStatus = (req, res) => {
+  const userId = getUserIdFromToken(req);
+  if (!userId) return res.status(401).json({ message: "인증이 필요합니다." });
+  const id = req.params.reviewId;
+  const r = reviews.find((x) => x.id === id);
+  if (!r) return res.status(404).json({ message: "리뷰를 찾을 수 없습니다." });
+  return res.json({ isLiked: r.likesBy.includes(userId), isDisliked: r.dislikesBy.includes(userId) });
+};
+
+// ===== Comments (instagram-style: only first-level replies) =====
+exports.getComments = (req, res) => {
+  const reviewId = req.params.reviewId;
+  const parentId = req.query.parentId || null; // null for roots
+  const page = Math.max(1, Number(req.query.page || 1));
+  const limit = Math.max(1, Math.min(50, Number(req.query.limit || 10)));
+  const sort = req.query.sort || "recent"; // recent|likes
+
+  let list = reviewComments.filter((c) => c.reviewId === reviewId && (parentId ? c.parentId === parentId : c.parentId === null));
+  if (sort === "likes") list.sort((a, b) => (b.likesBy.length - a.likesBy.length) || new Date(b.createdAt) - new Date(a.createdAt));
+  else list.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+  const total = list.length;
+  const items = list.slice((page - 1) * limit, (page - 1) * limit + limit);
+
+  // for each root comment, include repliesCount
+  if (!parentId) {
+    const ids = new Set(items.map((i) => i.id));
+    const repliesCountByRoot = {};
+    for (const c of reviewComments) {
+      if (c.reviewId !== reviewId || c.parentId == null) continue;
+      // reply attaches to root id (parentId is root id by rule)
+      repliesCountByRoot[c.parentId] = (repliesCountByRoot[c.parentId] || 0) + 1;
+    }
+    // decorate
+    return res.json({
+      items: items.map((i) => ({ ...i, repliesCount: repliesCountByRoot[i.id] || 0 })),
+      page,
+      limit,
+      total,
+    });
+  }
+  return res.json({ items, page, limit, total });
+};
+
+exports.addComment = (req, res) => {
+  const userId = getUserIdFromToken(req);
+  if (!userId) return res.status(401).json({ message: "인증이 필요합니다." });
+  const reviewId = req.params.reviewId;
+  const { content, isSpoiler = false, parentCommentId = null } = req.body || {};
+  if (!content) return res.status(400).json({ message: "content 필요" });
+  const now = new Date().toISOString();
+
+  let parentId = null;
+  if (parentCommentId) {
+    const root = resolveRootParent(parentCommentId);
+    if (root) parentId = root; // enforce first-level reply attached to root
+  }
+
+  const item = {
+    id: uid(),
+    reviewId,
+    userId,
+    content: String(content),
+    isSpoiler: !!isSpoiler,
+    parentId, // null for root, rootId for reply
+    likesBy: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+  reviewComments.unshift(item);
+  return res.status(201).json(item);
+};
+
+exports.updateComment = (req, res) => {
+  const userId = getUserIdFromToken(req);
+  if (!userId) return res.status(401).json({ message: "인증이 필요합니다." });
+  const id = req.params.commentId;
+  const idx = reviewComments.findIndex((c) => c.id === id);
+  if (idx === -1) return res.status(404).json({ message: "댓글을 찾을 수 없습니다." });
+  if (reviewComments[idx].userId !== userId) return res.status(403).json({ message: "수정 권한이 없습니다." });
+  const { content, isSpoiler } = req.body || {};
+  if (content != null) reviewComments[idx].content = String(content);
+  if (isSpoiler != null) reviewComments[idx].isSpoiler = !!isSpoiler;
+  reviewComments[idx].updatedAt = new Date().toISOString();
+  return res.json(reviewComments[idx]);
+};
+
+exports.deleteComment = (req, res) => {
+  const userId = getUserIdFromToken(req);
+  if (!userId) return res.status(401).json({ message: "인증이 필요합니다." });
+  const id = req.params.commentId;
+  const idx = reviewComments.findIndex((c) => c.id === id);
+  if (idx === -1) return res.status(404).json({ message: "댓글을 찾을 수 없습니다." });
+  if (reviewComments[idx].userId !== userId) return res.status(403).json({ message: "삭제 권한이 없습니다." });
+  // remove target and its replies (by parentId)
+  const rootId = reviewComments[idx].parentId ? reviewComments[idx].parentId : reviewComments[idx].id;
+  const toRemove = new Set([id]);
+  // Only one-level replies exist but handle safe removal of children of this id
+  for (const c of reviewComments) {
+    if (c.parentId === id) toRemove.add(c.id);
+  }
+  reviewComments = reviewComments.filter((c) => !toRemove.has(c.id));
+  return res.json({ message: "댓글이 삭제되었습니다.", id });
+};
+
+exports.getCommentReactionStatus = (req, res) => {
+  const userId = getUserIdFromToken(req);
+  if (!userId) return res.status(401).json({ message: "인증이 필요합니다." });
+  const id = req.params.commentId;
+  const c = reviewComments.find((x) => x.id === id);
+  if (!c) return res.status(404).json({ message: "댓글을 찾을 수 없습니다." });
+  return res.json({ liked: c.likesBy.includes(userId) });
+};
+
+exports.reactToComment = (req, res) => {
+  const userId = getUserIdFromToken(req);
+  if (!userId) return res.status(401).json({ message: "인증이 필요합니다." });
+  const id = req.params.commentId;
+  const c = reviewComments.find((x) => x.id === id);
+  if (!c) return res.status(404).json({ message: "댓글을 찾을 수 없습니다." });
+  const liked = c.likesBy.includes(userId);
+  c.likesBy = liked ? c.likesBy.filter((u) => u !== userId) : [userId, ...c.likesBy];
+  return res.json(c);
+};

--- a/server/routes/reviewRoutes.js
+++ b/server/routes/reviewRoutes.js
@@ -1,0 +1,26 @@
+const express = require("express");
+const router = express.Router();
+const reviewController = require("../controllers/reviewController");
+
+// Reviews
+router.post("/", reviewController.createReview);
+router.get("/movie/:movieId", reviewController.getReviewsByMovie);
+router.get("/movie/:movieId/stats", reviewController.getMovieStats);
+router.get("/user/me", reviewController.getMyReviews);
+router.get("/:reviewId", reviewController.getReviewById);
+router.put("/:reviewId", reviewController.updateReview);
+router.delete("/:reviewId", reviewController.deleteReview);
+router.post("/:reviewId/like", reviewController.likeReview);
+router.post("/:reviewId/dislike", reviewController.dislikeReview);
+router.get("/:reviewId/reaction", reviewController.getReactionStatus);
+
+// Comments (Instagram-style: replies attach to root comment only)
+router.get("/:reviewId/comments", reviewController.getComments);
+router.post("/:reviewId/comments", reviewController.addComment);
+router.put("/:reviewId/comments/:commentId", reviewController.updateComment);
+router.delete("/:reviewId/comments/:commentId", reviewController.deleteComment);
+router.get("/:reviewId/comments/:commentId/reaction", reviewController.getCommentReactionStatus);
+router.post("/:reviewId/comments/:commentId/react", reviewController.reactToComment);
+
+module.exports = router;
+

--- a/server/server.js
+++ b/server/server.js
@@ -5,12 +5,17 @@ require("dotenv").config();
 
 const userRoutes = require("./routes/userRoutes");
 const movieRoutes = require("./routes/movieRoutes");
+const reviewRoutes = require("./routes/reviewRoutes");
 
 const app = express();
 const PORT = process.env.PORT || 5001;
 
+const allowedOrigins = ["http://localhost:3000", "http://localhost:5173"];
 const corsOptions = {
-  origin: "http://localhost:3000",
+  origin: function (origin, callback) {
+    if (!origin || allowedOrigins.includes(origin)) return callback(null, true);
+    return callback(null, true); // dev: allow others
+  },
   credentials: true,
 };
 
@@ -19,6 +24,7 @@ app.use(bodyParser.json());
 
 app.use("/users", userRoutes);
 app.use("/movies", movieRoutes);
+app.use("/reviews", reviewRoutes);
 
 app.listen(PORT, () => {
   console.log(`서버가 포트 ${PORT}에서 실행 중입니다.`);

--- a/src/features/movies/MovieDetail.tsx
+++ b/src/features/movies/MovieDetail.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import { IMAGE_BASE_URL } from "../../config";
 import { getCurrentUser, isMovieLiked, toggleLike } from "../../shared/utils/userData";
-import CommentsThread from './components/CommentsThread';
+import ReviewsSection from '../../features/reviews/ReviewsSection';
 import { useQuery } from '@tanstack/react-query';
 import { fetchMovieDetail } from './api';
 
@@ -69,7 +69,7 @@ function MovieDetail() {
       </div>
 
       <hr style={{ margin: "24px 0" }} />
-      <CommentsThread movieId={Number(movieID)} user={user} />
+      <ReviewsSection movieId={Number(movieID)} user={user} />
     </div>
   );
 }

--- a/src/features/reviews/ReviewsSection.tsx
+++ b/src/features/reviews/ReviewsSection.tsx
@@ -1,0 +1,267 @@
+import React, { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  fetchReviewsByMovie,
+  fetchMovieReviewStats,
+  reactReview,
+  fetchReviewRootComments,
+  fetchReviewReplies,
+  addReviewComment,
+  updateReviewComment,
+  deleteReviewComment,
+  createReview,
+  reactReviewComment,
+} from './api';
+
+type User = { id: string; nick: string } | null;
+
+const CommentBox: React.FC<{ onSubmit: (text: string)=>void; placeholder?: string; initial?: string; onCancel?: ()=>void }>
+  = ({ onSubmit, placeholder, initial = '', onCancel }) => {
+  const [text, setText] = useState(initial);
+  return (
+    <div style={{ display:'flex', gap:8, marginTop:8 }}>
+      <textarea value={text} onChange={(e)=>setText(e.target.value)} placeholder={placeholder} rows={3} style={{ flex:1, padding:8 }} />
+      <div style={{ display:'flex', flexDirection:'column', gap:8 }}>
+        <button onClick={()=>{ if(text.trim()) { onSubmit(text.trim()); setText(''); }}} style={{ height:40 }}>등록</button>
+        {onCancel && <button onClick={onCancel} style={{ height:32 }}>취소</button>}
+      </div>
+    </div>
+  );
+};
+
+const ReviewItem: React.FC<{
+  review: any;
+  user: User;
+}> = ({ review, user }) => {
+  const qc = useQueryClient();
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const toggleExpanded = (rootId: string) => setExpanded(prev => ({ ...prev, [rootId]: !prev[rootId] }));
+
+  // Root comments
+  const { data: roots, refetch: refetchRoots } = useQuery({
+    queryKey: ['review', review._id, 'comments', 'root'],
+    queryFn: () => fetchReviewRootComments(review._id, 1, 10, 'recent'),
+  });
+
+  const addRoot = useMutation({
+    mutationFn: (text: string) => addReviewComment(review._id, text),
+    onSuccess: () => { qc.invalidateQueries({ queryKey: ['review', review._id, 'comments', 'root'] }); },
+  });
+
+  const addReply = useMutation({
+    mutationFn: ({ rootId, text }: { rootId: string; text: string }) => addReviewComment(review._id, text, rootId),
+    onSuccess: (_d, vars) => {
+      qc.invalidateQueries({ queryKey: ['review', review._id, 'comments', vars.rootId] });
+      qc.invalidateQueries({ queryKey: ['review', review._id, 'comments', 'root'] });
+    },
+  });
+
+  const editComment = useMutation({
+    mutationFn: ({ id, text }: { id: string; text: string }) => updateReviewComment(review._id, id, text),
+    onSuccess: (_d, vars) => {
+      qc.invalidateQueries({ queryKey: ['review', review._id, 'comments', 'root'] });
+      qc.invalidateQueries({ predicate: (q)=> Array.isArray(q.queryKey) && q.queryKey[0]==='review' && q.queryKey[2]==='comments' && q.queryKey[3]===vars.id });
+    }
+  });
+
+  const deleteCommentMut = useMutation({
+    mutationFn: (id: string) => deleteReviewComment(review._id, id),
+    onSuccess: (_d, id) => {
+      qc.invalidateQueries({ queryKey: ['review', review._id, 'comments', 'root'] });
+      qc.invalidateQueries({ predicate: (q)=> Array.isArray(q.queryKey) && q.queryKey[0]==='review' && q.queryKey[2]==='comments' && q.queryKey[3]===id });
+    }
+  });
+
+  const likeReviewMut = useMutation({
+    mutationFn: () => reactReview(review._id, 'like'),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['movie', review.movieId, 'reviews'] })
+  });
+  const dislikeReviewMut = useMutation({
+    mutationFn: () => reactReview(review._id, 'dislike'),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['movie', review.movieId, 'reviews'] })
+  });
+
+  return (
+    <div style={{ border:'1px solid #333', borderRadius:8, padding:12, marginBottom:12 }}>
+      <div style={{ display:'flex', alignItems:'center', gap:8 }}>
+        <div style={{ width:28, height:28, borderRadius:'50%', background:'#424685', color:'#fff', display:'inline-flex', alignItems:'center', justifyContent:'center', fontWeight:900 }}>
+          {String(review.userId).charAt(0).toUpperCase()}
+        </div>
+        <div style={{ color:'#ddd', fontWeight:700 }}>평점 {review.rating}</div>
+        <div style={{ color:'#888', fontSize:12, marginLeft:8 }}>{new Date(review.createdAt).toLocaleString()}</div>
+        <button onClick={()=> user ? likeReviewMut.mutate() : alert('로그인이 필요합니다.')} style={{ marginLeft:'auto', background:'transparent', border:'none', color:'#ffd166', cursor:'pointer' }}>좋아요 {review.likes || 0}</button>
+        <button onClick={()=> user ? dislikeReviewMut.mutate() : alert('로그인이 필요합니다.')} style={{ background:'transparent', border:'none', color:'#f88', cursor:'pointer' }}>싫어요 {review.dislikes || 0}</button>
+      </div>
+      <div style={{ color:'#eee', whiteSpace:'pre-wrap', marginTop:6 }}>{review.content}</div>
+
+      <div style={{ marginTop: 10 }}>
+        <CommentBox placeholder='댓글을 남겨보세요' onSubmit={(t)=>{ if(!user) return alert('로그인이 필요합니다.'); addRoot.mutate(t); }} />
+        <div style={{ marginTop: 8 }}>
+          {(roots?.items || roots?.reviews || roots || []).map((root: any) => (
+            <RootCommentView key={root.id}
+              reviewId={review._id}
+              user={user}
+              root={root}
+              expanded={!!expanded[root.id]}
+              onToggle={()=>toggleExpanded(root.id)}
+              onReply={(text)=>{ if(!user) return alert('로그인이 필요합니다.'); addReply.mutate({ rootId: root.id, text }); }}
+              onEdit={(id, text)=> editComment.mutate({ id, text })}
+              onDelete={(id)=> { if (window.confirm('정말로 삭제하시겠습니까?')) deleteCommentMut.mutate(id); }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const RootCommentView: React.FC<{
+  reviewId: string;
+  user: User;
+  root: any;
+  expanded: boolean;
+  onToggle: ()=>void;
+  onReply: (text: string)=>void;
+  onEdit: (id: string, text: string)=>void;
+  onDelete: (id: string)=>void;
+}> = ({ reviewId, user, root, expanded, onToggle, onReply, onEdit, onDelete }) => {
+  const [editing, setEditing] = useState(false);
+  const [replyOpen, setReplyOpen] = useState(false);
+  const { data: replies } = useQuery({
+    enabled: expanded,
+    queryKey: ['review', reviewId, 'comments', root.id],
+    queryFn: () => fetchReviewReplies(reviewId, root.id, 1, 50, 'recent'),
+  });
+  const likeCommentMut = useMutation({
+    mutationFn: () => reactReviewComment(reviewId, root.id),
+  });
+
+  return (
+    <div style={{ padding:'8px 0', borderBottom:'1px solid #222' }}>
+      <div style={{ display:'flex', alignItems:'center', gap:8 }}>
+        <div style={{ width:28, height:28, borderRadius:'50%', background:'#424685', color:'#fff', display:'inline-flex', alignItems:'center', justifyContent:'center', fontWeight:900 }}>
+          {String(root.userId).charAt(0).toUpperCase()}
+        </div>
+        <div style={{ color:'#ddd', fontWeight:700 }}>{root.userId}</div>
+        <div style={{ color:'#888', fontSize:12 }}>{new Date(root.createdAt).toLocaleString()}</div>
+        <button onClick={()=> user ? likeCommentMut.mutate() : alert('로그인이 필요합니다.')} style={{ marginLeft:'auto', background:'transparent', border:'none', color:'#ffd166', cursor:'pointer' }}>
+          ★ {root.likesBy?.length || 0}
+        </button>
+      </div>
+      {!editing ? (
+        <div style={{ color:'#eee', whiteSpace:'pre-wrap', marginTop:6 }}>{root.content}</div>
+      ) : (
+        <CommentBox initial={root.content} onSubmit={(t)=>{ onEdit(root.id, t); setEditing(false);} } onCancel={()=>setEditing(false)} />
+      )}
+      <div style={{ display:'flex', gap:8, marginTop:6 }}>
+        <button onClick={()=> setReplyOpen(v=>!v)}>답글</button>
+        <button onClick={onToggle}>{expanded ? '답글 숨기기' : `답글 ${(root.repliesCount||0)}개 보기`}</button>
+        {/* NOTE: 사용자 닉은 서버에 없음(데모). 본인 여부 판단은 생략 */}
+        <button onClick={()=>setEditing(true)}>수정</button>
+        <button onClick={()=> onDelete(root.id)}>삭제</button>
+      </div>
+      {replyOpen && <CommentBox placeholder='답글을 입력하세요' onSubmit={(t)=>{ onReply(t); setReplyOpen(false);} } onCancel={()=>setReplyOpen(false)} />}
+      {expanded && (
+        <div style={{ marginLeft: 24, marginTop:8 }}>
+          {(replies?.items || []).map((rep: any) => (
+            <ChildCommentView key={rep.id} reviewId={reviewId} user={user} c={rep} onEdit={onEdit} onDelete={onDelete} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const ChildCommentView: React.FC<{ reviewId: string; user: User; c: any; onEdit: (id: string, text: string)=>void; onDelete: (id: string)=>void }>
+  = ({ reviewId, user, c, onEdit, onDelete }) => {
+  const [editing, setEditing] = useState(false);
+  const likeCommentMut = useMutation({ mutationFn: () => reactReviewComment(reviewId, c.id) });
+  return (
+    <div style={{ padding:'8px 0', borderBottom:'1px solid #222' }}>
+      <div style={{ display:'flex', alignItems:'center', gap:8 }}>
+        <div style={{ width:24, height:24, borderRadius:'50%', background:'#555', color:'#fff', display:'inline-flex', alignItems:'center', justifyContent:'center', fontWeight:900 }}>
+          {String(c.userId).charAt(0).toUpperCase()}
+        </div>
+        <div style={{ color:'#ddd', fontWeight:700 }}>{c.userId}</div>
+        <div style={{ color:'#888', fontSize:12 }}>{new Date(c.createdAt).toLocaleString()}</div>
+        <button onClick={()=> user ? likeCommentMut.mutate() : alert('로그인이 필요합니다.')} style={{ marginLeft:'auto', background:'transparent', border:'none', color:'#ffd166', cursor:'pointer' }}>
+          ★ {c.likesBy?.length || 0}
+        </button>
+      </div>
+      {!editing ? (
+        <div style={{ color:'#eee', whiteSpace:'pre-wrap', marginTop:6 }}>{c.content}</div>
+      ) : (
+        <CommentBox initial={c.content} onSubmit={(t)=>{ onEdit(c.id, t); setEditing(false);} } onCancel={()=>setEditing(false)} />
+      )}
+      <div style={{ display:'flex', gap:8, marginTop:6 }}>
+        <button onClick={()=>setEditing(true)}>수정</button>
+        <button onClick={()=>{ if(window.confirm('정말로 삭제하시겠습니까?')) onDelete(c.id); }}>삭제</button>
+      </div>
+    </div>
+  );
+};
+
+const CreateReviewBox: React.FC<{ movieId: number; onCreated: ()=>void; user: User }>
+  = ({ movieId, onCreated, user }) => {
+  const [rating, setRating] = useState(5);
+  const [content, setContent] = useState('');
+  const qc = useQueryClient();
+  const mut = useMutation({
+    mutationFn: () => createReview({ movieId, rating, content }),
+    onSuccess: (created) => {
+      setContent('');
+      // Optimistically prepend the created review to the cached list
+      qc.setQueryData(['movie', movieId, 'reviews'], (prev: any) => {
+        if (!prev) return prev;
+        // support both {reviews:[]} and {items:[]}
+        if (Array.isArray(prev)) return [created, ...prev];
+        if (Array.isArray(prev.reviews)) {
+          const total = (prev.total || prev.reviews.length) + 1;
+          return { ...prev, reviews: [created, ...prev.reviews], total, totalPages: Math.max(1, Math.ceil(total / (prev.limit || 10))) };
+        }
+        if (Array.isArray(prev.items)) {
+          const total = (prev.total || prev.items.length) + 1;
+          return { ...prev, items: [created, ...prev.items], total, totalPages: Math.max(1, Math.ceil(total / (prev.limit || 10))) };
+        }
+        return prev;
+      });
+      qc.invalidateQueries({ queryKey: ['movie', movieId, 'reviewStats'] });
+      onCreated();
+    },
+  });
+  return (
+    <div style={{ border:'1px dashed #444', borderRadius:8, padding:12, margin:'12px 0' }}>
+      <div style={{ display:'flex', alignItems:'center', gap:8 }}>
+        <span style={{ color:'#ddd' }}>평점</span>
+        <input type='number' min={1} max={5} value={rating} onChange={e=>setRating(Number(e.target.value))} style={{ width:60 }}/>
+      </div>
+      <textarea value={content} onChange={e=>setContent(e.target.value)} placeholder='리뷰를 작성하세요' rows={4} style={{ width:'100%', marginTop:8, padding:8 }} />
+      <div style={{ display:'flex', gap:8, marginTop:8 }}>
+        <button onClick={()=>{ if(!user) return alert('로그인이 필요합니다.'); if(!content.trim()) return; mut.mutate(); }}>리뷰 등록</button>
+      </div>
+    </div>
+  );
+};
+
+const ReviewsSection: React.FC<{ movieId: number; user: User }> = ({ movieId, user }) => {
+  const qc = useQueryClient();
+  const { data: stats } = useQuery({ queryKey: ['movie', movieId, 'reviewStats'], queryFn: () => fetchMovieReviewStats(movieId) });
+  const { data: list, refetch } = useQuery({ queryKey: ['movie', movieId, 'reviews'], queryFn: () => fetchReviewsByMovie(movieId, 1, 10, { sort: 'recent' }) });
+
+  const items = useMemo(() => (list?.reviews || list?.items || list || []), [list]);
+
+  return (
+    <div style={{ marginTop: 24 }}>
+      <h3 style={{ color:'#fff' }}>리뷰</h3>
+      <div style={{ color:'#ccc', marginBottom: 8 }}>평균 {stats?.averageRating || 0} / 리뷰 {stats?.totalReviews || 0}</div>
+      <CreateReviewBox movieId={movieId} user={user} onCreated={()=>{ qc.invalidateQueries({ queryKey: ['movie', movieId, 'reviews'] }); qc.invalidateQueries({ queryKey: ['movie', movieId, 'reviewStats'] }); }} />
+      <div>
+        {items.map((rv: any) => (
+          <ReviewItem key={rv._id} review={rv} user={user} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ReviewsSection;

--- a/src/features/reviews/api.ts
+++ b/src/features/reviews/api.ts
@@ -1,0 +1,100 @@
+const BASE_URL = 'http://localhost:5001';
+
+function authHeaders() {
+  const token = typeof localStorage !== 'undefined' ? localStorage.getItem('token') : null;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+// Reviews
+export async function fetchReviewsByMovie(movieId: number, page = 1, limit = 10, options?: { sort?: 'recent'|'rating'|'helpful'; ratingFilter?: number; hasSpoiler?: boolean }) {
+  const params = new URLSearchParams();
+  params.set('page', String(page));
+  params.set('limit', String(limit));
+  if (options?.sort) params.set('sort', options.sort);
+  if (typeof options?.ratingFilter === 'number') params.set('ratingFilter', String(options.ratingFilter));
+  if (typeof options?.hasSpoiler === 'boolean') params.set('hasSpoiler', String(options.hasSpoiler));
+  const res = await fetch(`${BASE_URL}/reviews/movie/${movieId}?${params.toString()}`);
+  if (!res.ok) throw new Error('Failed to fetch reviews');
+  return res.json();
+}
+
+export async function fetchMovieReviewStats(movieId: number) {
+  const res = await fetch(`${BASE_URL}/reviews/movie/${movieId}/stats`);
+  if (!res.ok) throw new Error('Failed to fetch review stats');
+  return res.json();
+}
+
+export async function createReview(payload: { movieId: number; rating: number; content: string; tags?: string[]; isSpoiler?: boolean }) {
+  const res = await fetch(`${BASE_URL}/reviews`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function reactReview(reviewId: string, type: 'like'|'dislike') {
+  const path = type === 'like' ? 'like' : 'dislike';
+  const res = await fetch(`${BASE_URL}/reviews/${reviewId}/${path}`, {
+    method: 'POST',
+    headers: { ...authHeaders() },
+  });
+  if (!res.ok) throw new Error('Failed to react review');
+  return res.json();
+}
+
+// Comments (instagram-style: replies attach to root)
+export async function fetchReviewRootComments(reviewId: string, page = 1, limit = 10, sort: 'recent'|'likes' = 'recent') {
+  const params = new URLSearchParams({ page: String(page), limit: String(limit), sort });
+  const res = await fetch(`${BASE_URL}/reviews/${reviewId}/comments?${params.toString()}`);
+  if (!res.ok) throw new Error('Failed to fetch comments');
+  return res.json();
+}
+
+export async function fetchReviewReplies(reviewId: string, rootCommentId: string, page = 1, limit = 50, sort: 'recent'|'likes' = 'recent') {
+  const params = new URLSearchParams({ parentId: rootCommentId, page: String(page), limit: String(limit), sort });
+  const res = await fetch(`${BASE_URL}/reviews/${reviewId}/comments?${params.toString()}`);
+  if (!res.ok) throw new Error('Failed to fetch replies');
+  return res.json();
+}
+
+export async function addReviewComment(reviewId: string, content: string, parentCommentId?: string) {
+  const res = await fetch(`${BASE_URL}/reviews/${reviewId}/comments`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify({ content, parentCommentId: parentCommentId || null }),
+  });
+  if (!res.ok) throw new Error('Failed to add comment');
+  return res.json();
+}
+
+export async function updateReviewComment(reviewId: string, commentId: string, content: string) {
+  const res = await fetch(`${BASE_URL}/reviews/${reviewId}/comments/${commentId}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify({ content }),
+  });
+  if (!res.ok) throw new Error('Failed to update comment');
+  return res.json();
+}
+
+export async function deleteReviewComment(reviewId: string, commentId: string) {
+  const res = await fetch(`${BASE_URL}/reviews/${reviewId}/comments/${commentId}`, {
+    method: 'DELETE',
+    headers: { ...authHeaders() },
+  });
+  if (!res.ok) throw new Error('Failed to delete comment');
+  return res.json();
+}
+
+export async function reactReviewComment(reviewId: string, commentId: string) {
+  const res = await fetch(`${BASE_URL}/reviews/${reviewId}/comments/${commentId}/react`, {
+    method: 'POST',
+    headers: { ...authHeaders() },
+    body: JSON.stringify({ type: 'like' }),
+  });
+  if (!res.ok) throw new Error('Failed to react comment');
+  return res.json();
+}
+

--- a/src/shared/utils/userData.js
+++ b/src/shared/utils/userData.js
@@ -12,9 +12,19 @@ export async function getCurrentUser() {
     const res = await fetch("http://localhost:5001/users/protected", {
       headers: { Authorization: `Bearer ${token}` },
     });
-    if (!res.ok) return null;
-    const data = await res.json();
-    return { id: data.id, nick: data.nick };
+    if (res.ok) {
+      const data = await res.json();
+      return { id: data.id, nick: data.nick };
+    }
+    // Fallback: decode token payload (no verification) to keep UX after server restart
+    const parts = token.split('.')
+    if (parts.length === 3) {
+      try {
+        const payload = JSON.parse(atob(parts[1]));
+        if (payload && payload.id) return { id: payload.id, nick: payload.id };
+      } catch {}
+    }
+    return null;
   } catch (e) {
     return null;
   }
@@ -93,4 +103,3 @@ export function getReviewedMovies(userId) {
   }
   return Array.from(map.values());
 }
-


### PR DESCRIPTION
 요약
  
  - 영화 리뷰(의견) 기능을 서버/클라이언트 전반에 추가 및 일원화.
  - 리뷰별 1-뎁스 대댓글(인스타 스타일)과 좋아요/싫어요 반응 도입.
  - 영화 상세 페이지에 리뷰 작성/목록/반응/대댓글 UI 통합.
  - 스터디용 문서 추가.
  
  변경 사항
  
  - 서버(Express)
      - 리뷰 라우팅 추가: /reviews 등록.
      - 컨트롤러 추가: server/controllers/reviewController.js
      - 리뷰 CRUD, 반응(좋아요/싫어요 상호배타 토글), 통계, 댓글(1-뎁스 대댓글), 댓글 좋아요.
      - 응답 스펙 정합화: `Review` 모델 필드, 목록 응답 `{ reviews, total, page, totalPages }`, 반응 상태 `{ isLiked, isDisliked }`.
  - 라우트 파일 추가: server/routes/reviewRoutes.js
  - CORS 개선: 3000, 5173 허용(개발)
  - 서버 등록: server/server.js에 app.use('/reviews', reviewRoutes)
  - 프론트엔드
      - 리뷰 API 클라이언트: src/features/reviews/api.ts
      - 영화 상세 리뷰 섹션: src/features/reviews/ReviewsSection.tsx
      - 리뷰 작성(로그인), 목록, 좋아요/싫어요, 리뷰별 댓글/대댓글(루트만), 삭제 확인 팝업
      - 작성 성공 시 목록에 즉시 반영(낙관적 업데이트)
  - 영화 상세 페이지 연동: src/features/movies/MovieDetail.tsx에 ReviewsSection 추가(의견=리뷰로 일원화)
  - 유저 토큰 처리 안정화: src/shared/utils/userData.js (서버 재시작 시 토큰 payload 디코드로 id 복구)
  - 참고: 영화 단위 로컬 댓글 컴포넌트(CommentsThread)는 파일은 유지, 상세 화면에서는 미사용
  - 문서
      - 스터디 가이드 추가: study/reviews-study.md (개념, 실무 포인트, API 샘플)
  
  신규/변경 API
  
  - POST /reviews (인증): { movieId, rating(1..5), content, tags?, isSpoiler? } → Review
  - GET /reviews/movie/:movieId: { reviews, total, page, totalPages }
  - GET /reviews/movie/:movieId/stats: { averageRating, totalReviews }
  - GET /reviews/user/me (인증): Review[]
  - GET /reviews/:reviewId → Review
  - PUT /reviews/:reviewId (인증/본인) → Review
  - DELETE /reviews/:reviewId (인증/본인) → { message }
  - POST /reviews/:reviewId/like|dislike (인증) → Review
  - GET /reviews/:reviewId/reaction (인증) → { isLiked, isDisliked }
  - 댓글(리뷰 단위, 1-뎁스)
      - GET /:reviewId/comments?parentId=&page=&limit=&sort=recent|likes
      - POST /:reviewId/comments (인증) { content, parentCommentId? } → 항상 루트에 부착
      - PUT/DELETE /:reviewId/comments/:commentId (인증/본인)
      - POST /:reviewId/comments/:commentId/react (인증): 좋아요 토글
  
  UI/UX
  
  - 리뷰 작성 폼: 영화 상세 페이지 하단
  - 리뷰 카드: 평점/내용/시간/좋아요·싫어요
  - 리뷰 댓글: 루트에만 “답글” 버튼, “답글 N개 보기/숨기기” 토글
  - 삭제 시 확인 팝업(“정말로 삭제하시겠습니까?”)
  - 작성/삭제/반응 후 즉시 반영(낙관적 업데이트 + 캐시 무효화)
  
  테스트 방법
  
  - 서버 실행: cd server && node server.js (SECRET_KEY 설정)
  - 회원가입/로그인 → 브라우저 LocalStorage에 token 저장됨
  - 영화 상세 페이지:
      - 리뷰 작성(1개/영화): 성공 → 즉시 목록 상단에 표시, 중복 작성 시 409
      - 좋아요/싫어요: 상호배타 토글
      - 루트 댓글 작성 → “답글 N개 보기/숨기기” 확인
      - 루트 댓글에 답글 작성(자식에는 답글 버튼 노출 없음)
      - 댓글/답글 삭제 시 확인 팝업 동작 확인
  - API 직접 호출(선택): study/reviews-study.md의 cURL 예제 참고
  
  호환/영향
  
  - 기존 영화 단위 로컬 댓글은 화면에서 제거(컴포넌트 파일은 유지)
  - 신규 리뷰 API 응답 스펙 사용(목록은 reviews 키)