### PR TITLE
refactor(Mylist) : 마이리스트 쿠키에서 서버 연동으로 전환 및 마이리스트에서 리뷰 클릭시 포커싱 되는 기능 추가

### DIFF
--- a/src/features/movies/MovieDetail.tsx
+++ b/src/features/movies/MovieDetail.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router-dom";
 import { IMAGE_BASE_URL } from "../../config";
 import { getCurrentUser, isMovieLiked, toggleLike } from "../../shared/utils/userData";
 import ReviewsSection from '../../features/reviews/ReviewsSection';
@@ -8,6 +8,8 @@ import { fetchMovieDetail } from './api';
 
 function MovieDetail() {
   const { movieID } = useParams<{ movieID: string }>();
+  const [searchParams] = useSearchParams();
+  const focusReviewId = searchParams.get('review') || undefined;
   const [movie, setMovie] = useState<any>(null);
   const [loading, setLoading] = useState(true);
   const [user, setUser] = useState<{ id: string; nick: string } | null>(null);
@@ -69,7 +71,7 @@ function MovieDetail() {
       </div>
 
       <hr style={{ margin: "24px 0" }} />
-      <ReviewsSection movieId={Number(movieID)} user={user} />
+      <ReviewsSection movieId={Number(movieID)} user={user} focusReviewId={focusReviewId} />
     </div>
   );
 }

--- a/src/features/movies/components/MovieCard.tsx
+++ b/src/features/movies/components/MovieCard.tsx
@@ -4,8 +4,8 @@ import { Link } from "react-router-dom";
 import { IMAGE_BASE_URL } from "../../../config";
 import {
   getCurrentUser,
-  isMovieLiked,
-  toggleLike,
+  isBookmarked,
+  toggleBookmark,
 } from "../../../shared/utils/userData";
 
 type MovieSummary = {
@@ -23,9 +23,10 @@ type Props = {
   movieName?: string;
   movie?: MovieSummary;
   movieData?: MovieSummary;
+  to?: string; // optional custom link
 };
 
-function Movie({ image, movieID, movieName, movie, movieData }: Props) {
+function Movie({ image, movieID, movieName, movie, movieData, to }: Props) {
   const item = movie || movieData || null;
   const derivedId = movieID || item?.id;
   const derivedTitle = movieName || item?.title || item?.name;
@@ -40,7 +41,7 @@ function Movie({ image, movieID, movieName, movie, movieData }: Props) {
     (async () => {
       const u = await getCurrentUser();
       if (mounted) setUser(u);
-      if (mounted && u && derivedId) setLiked(isMovieLiked(u.id, derivedId));
+      if (mounted && u && derivedId) setLiked(isBookmarked(u.id, derivedId));
     })();
     return () => {
       mounted = false;
@@ -55,14 +56,14 @@ function Movie({ image, movieID, movieName, movie, movieData }: Props) {
       return;
     }
     const summary = (item || { id: derivedId, title: derivedTitle }) as MovieSummary;
-    const res = toggleLike(user.id, summary as any);
+    const res = toggleBookmark(user.id, summary as any);
     setLiked(res.liked);
   };
 
   return (
     <Col lg={6} md={8} xs={24}>
       <div style={{ position: "relative" }}>
-        <Link to={`/movie/${derivedId}`}>
+        <Link to={to || `/movie/${derivedId}`}>
           {derivedPoster ? (
             <img
               style={{ width: "100%", height: "400px", objectFit: "cover" }}

--- a/src/features/mylist/MyList.tsx
+++ b/src/features/mylist/MyList.tsx
@@ -3,13 +3,14 @@ import Menu from '../../shared/components/Sidebar/Menu';
 import { Row } from 'antd';
 import Movie from '../movies/components/MovieCard';
 import './MyList.css';
-import { getLikedMovies, getReviewedMovies } from '../../shared/utils/userData';
+import { getBookmarks, clearBookmarks } from '../../shared/utils/userData';
+import { fetchMovieDetail } from '../movies/api';
 
 const MyList = () => {
   const [userId, setUserId] = useState<string>('');
-  const [liked, setLiked] = useState<any[]>([]);
+  const [bookmarks, setBookmarks] = useState<any[]>([]);
   const [reviewed, setReviewed] = useState<any[]>([]);
-  const [activeTab, setActiveTab] = useState<'liked' | 'reviewed'>('liked');
+  const [activeTab, setActiveTab] = useState<'bookmarks' | 'reviewed'>('bookmarks');
 
   useEffect(() => {
     const token = localStorage.getItem('token');
@@ -21,13 +22,37 @@ const MyList = () => {
       .then((data) => {
         if (!data?.id) return;
         setUserId(data.id);
-        setLiked(getLikedMovies(data.id));
-        setReviewed(getReviewedMovies(data.id));
+        setBookmarks(getBookmarks(data.id));
+        // Fetch my reviews from backend and hydrate with movie summaries
+        fetch('http://localhost:5001/reviews/user/me', {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+          .then((r) => r.json())
+          .then(async (reviews: any[]) => {
+            if (!Array.isArray(reviews)) return setReviewed([]);
+            const hydrated = await Promise.all(
+              reviews.map(async (rv) => {
+                try {
+                  const mv = await fetchMovieDetail(rv.movieId);
+                  return {
+                    id: mv.id,
+                    title: mv.title || mv.name,
+                    poster_path: mv.poster_path,
+                    to: `/movie/${mv.id}?review=${encodeURIComponent(rv._id)}`,
+                  };
+                } catch {
+                  return { id: rv.movieId, title: `영화 ${rv.movieId}`, to: `/movie/${rv.movieId}?review=${encodeURIComponent(rv._id)}` };
+                }
+              })
+            );
+            setReviewed(hydrated);
+          })
+          .catch(() => setReviewed([]));
       })
       .catch(() => {});
   }, []);
 
-  const list = activeTab === 'liked' ? liked : reviewed;
+  const list = activeTab === 'bookmarks' ? bookmarks : reviewed;
 
   return (
     <div className="mylistContainer">
@@ -36,18 +61,18 @@ const MyList = () => {
         <div className="mylistHeader">
           <h2 style={{ margin:0 }}>Mylist</h2>
           <div className="actions">
-            {activeTab==='liked' && (
-              <button onClick={()=>{ if(!userId) return; localStorage.setItem(`likedMovies_${userId}`, JSON.stringify([])); setLiked([]); }}>좋아요 비우기</button>
+            {activeTab==='bookmarks' && (
+              <button onClick={()=>{ if(!userId) return; clearBookmarks(userId); setBookmarks([]); }}>북마크 비우기</button>
             )}
             <button onClick={()=>window.scrollTo({top:0, behavior:'smooth'})}>맨위로</button>
           </div>
         </div>
         <div className="tabs">
           <button
-            className={activeTab === 'liked' ? 'tab active' : 'tab'}
-            onClick={() => setActiveTab('liked')}
+            className={activeTab === 'bookmarks' ? 'tab active' : 'tab'}
+            onClick={() => setActiveTab('bookmarks')}
           >
-            좋아요 ({liked.length})
+            북마크 ({bookmarks.length})
           </button>
           <button
             className={activeTab === 'reviewed' ? 'tab active' : 'tab'}
@@ -60,7 +85,7 @@ const MyList = () => {
           {list.length === 0 ? (
             <div className="emptyBox">비어있어요. 마음에 드는 영화를 추가해보세요.</div>
           ) : (
-            list.map((m) => <Movie key={m.id} movieData={m} />)
+            list.map((m) => <Movie key={m.id} movieData={m} to={m.to} />)
           )}
         </Row>
       </div>

--- a/src/shared/components/Sidebar/Menu.tsx
+++ b/src/shared/components/Sidebar/Menu.tsx
@@ -7,42 +7,47 @@ const Menu = () => {
   const navigate = useNavigate();
   const [nick, setNick] = useState<string>("");
   useEffect(() => {
-    const token = localStorage.getItem('token');
+    const token = localStorage.getItem("token");
     if (!token) return;
-    fetch('http://localhost:5001/users/protected', { headers: { Authorization: `Bearer ${token}` }})
-      .then(r=> r.ok ? r.json() : null)
-      .then(data => { if (data?.nick) setNick(data.nick); })
-      .catch(()=>{});
+    fetch("http://localhost:5001/users/protected", {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.nick) setNick(data.nick);
+      })
+      .catch(() => {});
   }, []);
-  const initials = nick ? nick.charAt(0).toUpperCase() : 'U';
+  const initials = nick ? nick.charAt(0).toUpperCase() : "U";
 
   const [scrolled, setScrolled] = useState<boolean>(false);
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 20);
     onScroll();
-    window.addEventListener('scroll', onScroll);
-    return () => window.removeEventListener('scroll', onScroll);
+    window.addEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll);
   }, []);
 
   return (
     <div className={`sidebarContainer`}>
-      <div className='title1'>
-        <Link to='/main'>
-          <img src={Logo} style={{ width: 200, paddingTop: 20 }} alt='' />
+      <div className="title1">
+        <Link to="/main">
+          <img src={Logo} style={{ width: 200, paddingTop: 20 }} alt="" />
         </Link>
-        <Link style={{ textDecoration: "none" }} to='/movies'>
+        <Link style={{ textDecoration: "none" }} to="/movies">
           <span>Movies</span>
         </Link>
         <span>Community</span>
-        <Link style={{ textDecoration: "none" }} to='/search'>
-          <span>Search</span>
-        </Link>
-        <Link style={{ textDecoration: "none" }} to='/mylist'>
+        <Link style={{ textDecoration: "none" }} to="/mylist">
           <span>Mylist</span>
         </Link>
       </div>
-      <div className='title2'>
-        <button className='avatarCircle' onClick={()=>navigate('/mypage')} title='프로필'>
+      <div className="title2">
+        <button
+          className="avatarCircle"
+          onClick={() => navigate("/mypage")}
+          title="프로필"
+        >
           {initials}
         </button>
       </div>

--- a/src/shared/utils/userData.js
+++ b/src/shared/utils/userData.js
@@ -1,6 +1,8 @@
 // Utilities to manage per-user likes and reviews in localStorage
 
 const STORAGE_KEYS = {
+  // For backward-compatibility, bookmarks reuse the previous likedMovies key
+  bookmarks: (userId) => `likedMovies_${userId}`,
   likes: (userId) => `likedMovies_${userId}`,
   reviews: (userId) => `reviews_${userId}`,
 };
@@ -30,9 +32,9 @@ export async function getCurrentUser() {
   }
 }
 
-export function getLikedMovies(userId) {
+export function getBookmarks(userId) {
   if (!userId) return [];
-  const raw = localStorage.getItem(STORAGE_KEYS.likes(userId));
+  const raw = localStorage.getItem(STORAGE_KEYS.bookmarks(userId));
   try {
     return raw ? JSON.parse(raw) : [];
   } catch {
@@ -40,13 +42,13 @@ export function getLikedMovies(userId) {
   }
 }
 
-export function isMovieLiked(userId, movieId) {
-  return getLikedMovies(userId).some((m) => m.id === movieId);
+export function isBookmarked(userId, movieId) {
+  return getBookmarks(userId).some((m) => m.id === movieId);
 }
 
-export function toggleLike(userId, movieSummary) {
+export function toggleBookmark(userId, movieSummary) {
   if (!userId || !movieSummary || !movieSummary.id) return { liked: false, list: [] };
-  const list = getLikedMovies(userId);
+  const list = getBookmarks(userId);
   const exists = list.find((m) => m.id === movieSummary.id);
   let next;
   if (exists) {
@@ -60,9 +62,19 @@ export function toggleLike(userId, movieSummary) {
     };
     next = [summary, ...list];
   }
-  localStorage.setItem(STORAGE_KEYS.likes(userId), JSON.stringify(next));
+  localStorage.setItem(STORAGE_KEYS.bookmarks(userId), JSON.stringify(next));
   return { liked: !exists, list: next };
 }
+
+export function clearBookmarks(userId) {
+  if (!userId) return;
+  localStorage.setItem(STORAGE_KEYS.bookmarks(userId), JSON.stringify([]));
+}
+
+// Backward-compatible aliases
+export const getLikedMovies = getBookmarks;
+export const isMovieLiked = isBookmarked;
+export const toggleLike = toggleBookmark;
 
 export function getReviews(userId) {
   if (!userId) return [];


### PR DESCRIPTION
 요약
  
  - 마이리스트: 좋아요 → 북마크로 용어/로직 정리, 서버 기반 내 리뷰 목록으로 재연동.
  - 리뷰 포커싱: MyList에서 영화 클릭 시 상세 화면에서 “내 리뷰 카드”로 스크롤 및 키보드 포커스.
  - 안정화: 서버 스펙 변화로 인해 안 보이던 리뷰 목록 원인 해결.
  - 문서: 프론트 구현/개념 정리 MD 추가, React.FC 개념 설명 포함.
  
  변경 사항
  
  - 북마크 전환
      - src/shared/utils/userData.js
      - 추가: `getBookmarks`, `isBookmarked`, `toggleBookmark`, `clearBookmarks`
      - 하위호환: `getLikedMovies`, `isMovieLiked`, `toggleLike`를 alias로 유지(기존 `likedMovies_*` 키 그대로 사용)
  - 마이리스트 개편
      - src/features/mylist/MyList.tsx
      - 탭: “좋아요” → “북마크”
      - 북마크: `getBookmarks()` 사용, “북마크 비우기”는 `clearBookmarks()` 사용
      - 리뷰: 서버 `GET /reviews/user/me`로 내 리뷰 불러오기 → 각 `movieId`로 `GET /movies/:id` 조회해 카드 hydrate
      - 링크: `/movie/:id?review=<리뷰ID>`로 생성하여 상세 페이지 포커싱 연동
  - src/features/movies/components/MovieCard.tsx
      - 북마크 API로 전환(`isBookmarked`/`toggleBookmark`)
      - `to` prop 지원(카드 링크 커스터마이즈)
  - 리뷰 포커싱(스크롤+키보드 포커스)
      - src/features/movies/MovieDetail.tsx
      - `?review=<id>` 쿼리 파싱 → `ReviewsSection`에 `focusReviewId` 전달
  - src/features/reviews/ReviewsSection.tsx
      - 해당 리뷰 카드에 `id="review-<id>"`, `tabIndex={-1}`, `ref` 부여
      - 포커싱 시 `scrollIntoView({ block:'start' }) + focus()` + 일시 하이라이트(outline)
  - 문서/스터디
      - study/frontend-reviews-mylist.md: 프론트 리뷰/마이리스트 구조, 포커싱 동작, 왜 안 보였는지, 테스트 체크리스트, React.FC 개념 추가
  
  문제 원인(왜 리뷰/마이리스트가 안 보였나)
  
  - 리뷰: 기존 마이리스트는 로컬스토리지 getReviewedMovies()만 보던 구조였는데, 리뷰 저장을 서버로 바꾸면서 로컬에 데이터가 없어 표시되지 않았음 → GET /reviews/user/me로 전환하며 해결.
  - 좋아요/북마크: 코드상 저장 키가 likedMovies_*였고 UI는 “북마크” 용어를 사용해 혼선 → 북마크 유틸로 명확화(키는 유지해 데이터는 그대로 사용).
  
  테스트 방법
  
  - 북마크
      - 아무 영화 카드에서 별 아이콘 클릭 → 북마크 토글
      - MyList → 북마크 탭에서 카드 목록 확인, “북마크 비우기”로 정리
  - 내 리뷰
      - 영화 상세 하단에서 리뷰 작성 → 등록 즉시 목록 상단 반영
      - MyList → 리뷰 탭에서 내 리뷰 목록 표시(서버 데이터 기준)
      - 리뷰 카드 클릭 → /movie/:id?review=<리뷰ID> 진입 → 상세에서 해당 리뷰 카드로 스크롤 및 포커스(시각적 하이라이트)
  - 중복 리뷰
      - 같은 영화에 두 번째 리뷰 등록 시 409 Conflict 정상 동작 확인
  
  코드 경로
  
  - 북마크 유틸: src/shared/utils/userData.js
  - 마이리스트: src/features/mylist/MyList.tsx
  - 영화 카드: src/features/movies/components/MovieCard.tsx
  - 영화 상세: src/features/movies/MovieDetail.tsx
  - 리뷰 섹션: src/features/reviews/ReviewsSection.tsx
  - 문서: study/frontend-reviews-mylist.md
  
  호환성/주의
  
  - 로컬스토리지 키는 그대로(likedMovies_*), 명칭만 북마크로 표기하여 기존 데이터 유지.
  - 서버가 인메모리인 환경에서는 재시작 시 리뷰 데이터 초기화(데모 한정). 운영에서는 DB 필요.
  
  후속 작업 제안
  
  - 리뷰 정렬/필터 UI(최신/도움됨/평점, 스포일러/평점 필터)
  - 댓글/리뷰 닉네임/아바타 노출(서버 응답 확장)
  - 실패/로딩 토스트 및 스켈레톤
  - DB 영속화 및 인덱싱/카운터 원자성 적용