### PR TITLE
refactor(Menu) : 메뉴 컴포넌트 메인 레이아웃으로 적용

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,11 @@
 import "./App.css";
+import "./index.css";
 import Login from "features/auth/Login";
 import CreateAccount from "features/auth/Account";
 import Main from "pages/Main/Main.jsx";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import Menu from "shared/components/Sidebar/Menu";
+import MainLayout from "shared/layouts/MainLayout";
 import ImageSlider from "shared/components/Slider/Slider";
 import Moviespage from "features/movies/MoviesPage";
 import Search from "features/search/Search";
@@ -20,16 +21,20 @@ function App() {
       <QueryClientProvider client={queryClient}>
         <BrowserRouter>
           <Routes>
+            {/* Auth routes (no layout) */}
             <Route path="/" element={<Login />} />
             <Route path="/account" element={<CreateAccount />} />
-            <Route path="/main" element={<Main />} />
-            <Route path="/menu" element={<Menu />} />
-            <Route path="/slider" element={<ImageSlider />} />
-            <Route path="/movies" element={<Moviespage />} />
-            <Route path="/search" element={<Search />} />
-            <Route path="/mypage" element={<MyPage />} />
-            <Route path="/mylist" element={<MyList />} />
-            <Route path="/movie/:movieID" element={<MovieDetail />} />
+
+            {/* App routes with shared layout (menu + content) */}
+            <Route element={<MainLayout />}>
+              <Route path="/main" element={<Main />} />
+              <Route path="/slider" element={<ImageSlider />} />
+              <Route path="/movies" element={<Moviespage />} />
+              <Route path="/search" element={<Search />} />
+              <Route path="/mypage" element={<MyPage />} />
+              <Route path="/mylist" element={<MyList />} />
+              <Route path="/movie/:movieID" element={<MovieDetail />} />
+            </Route>
           </Routes>
         </BrowserRouter>
       </QueryClientProvider>

--- a/src/features/movies/MoviesPage.tsx
+++ b/src/features/movies/MoviesPage.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useState, useRef } from "react";
 import "./MoviesPage.css";
-import Menu from "../../shared/components/Sidebar/Menu";
 import Movie from "./components/MovieCard";
 import { Row } from "antd";
 import { IMAGE_BASE_URL } from "../../config";
-import { useInfiniteQuery } from '@tanstack/react-query';
-import { fetchMovies, searchMovies } from './api';
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { fetchMovies, searchMovies } from "./api";
 
 const Moviespage = () => {
   const [view, setView] = useState<any>();
@@ -21,7 +20,7 @@ const Moviespage = () => {
     isFetchingNextPage,
     isFetching,
   } = useInfiniteQuery({
-    queryKey: ['movies', genre],
+    queryKey: ["movies", genre],
     initialPageParam: 1,
     queryFn: ({ pageParam }) => fetchMovies(Number(pageParam), genre),
     placeholderData: (prev) => prev as any,
@@ -29,7 +28,11 @@ const Moviespage = () => {
       // TMDB 응답: { page, total_pages }
       if (!lastPage) return undefined;
       const { page, total_pages } = lastPage;
-      if (typeof page === 'number' && typeof total_pages === 'number' && page < total_pages) {
+      if (
+        typeof page === "number" &&
+        typeof total_pages === "number" &&
+        page < total_pages
+      ) {
         return page + 1;
       }
       return undefined; // 더 이상 페이지 없음
@@ -45,16 +48,21 @@ const Moviespage = () => {
     hasNextPage: hasNextSearch,
     isLoading: isLoadingSearch,
   } = useInfiniteQuery({
-    queryKey: ['search-movies', query],
+    queryKey: ["search-movies", query],
     enabled: query.trim().length > 0,
     initialPageParam: 1,
     queryFn: ({ pageParam }) => searchMovies(query, Number(pageParam)),
     getNextPageParam: (lastPage: any) => {
       if (!lastPage) return undefined;
       const { page, total_pages } = lastPage;
-      if (typeof page === 'number' && typeof total_pages === 'number' && page < total_pages) return page + 1;
+      if (
+        typeof page === "number" &&
+        typeof total_pages === "number" &&
+        page < total_pages
+      )
+        return page + 1;
       return undefined;
-    }
+    },
   });
 
   const list = query.trim()
@@ -81,11 +89,19 @@ const Moviespage = () => {
           }
         }
       },
-      { root: null, rootMargin: '300px', threshold: 0.01 }
+      { root: null, rootMargin: "300px", threshold: 0.01 }
     );
     obs.observe(el);
     return () => obs.disconnect();
-  }, [query, isFetchingNextPage, hasNextPage, fetchNextPage, isFetchingNextSearch, hasNextSearch, fetchNextSearch]);
+  }, [
+    query,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextSearch,
+    hasNextSearch,
+    fetchNextSearch,
+  ]);
 
   const handleGenreClick = (selectedGenre) => {
     if (genre === selectedGenre) return;
@@ -96,17 +112,27 @@ const Moviespage = () => {
 
   return (
     <div className="mpgContainer">
-      <Menu />
       <div className="mpgTitle">
-        <div style={{ display:'flex', gap:12, alignItems:'center', marginBottom: 12 }}>
+        <div
+          style={{
+            display: "flex",
+            gap: 12,
+            alignItems: "center",
+            marginBottom: 12,
+          }}
+        >
           <input
             value={query}
-            onChange={(e)=>setQuery(e.target.value)}
+            onChange={(e) => setQuery(e.target.value)}
             placeholder="영화 제목 검색"
-            style={{ padding:'8px 10px', flex:1, maxWidth:400 }}
-            onKeyDown={(e)=>{ if(e.key==='Enter' && query.trim()){ /* trigger first page we rely on enabled */ } }}
+            style={{ padding: "8px 10px", flex: 1, maxWidth: 400 }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && query.trim()) {
+                /* trigger first page we rely on enabled */
+              }
+            }}
           />
-          {query && (<button onClick={()=>setQuery("")}>검색 지우기</button>)}
+          {query && <button onClick={() => setQuery("")}>검색 지우기</button>}
         </div>
         <div className="genreContainer">
           <ul>

--- a/src/features/mylist/MyList.tsx
+++ b/src/features/mylist/MyList.tsx
@@ -1,21 +1,22 @@
-import React, { useEffect, useState } from 'react';
-import Menu from '../../shared/components/Sidebar/Menu';
-import { Row } from 'antd';
-import Movie from '../movies/components/MovieCard';
-import './MyList.css';
-import { getBookmarks, clearBookmarks } from '../../shared/utils/userData';
-import { fetchMovieDetail } from '../movies/api';
+import React, { useEffect, useState } from "react";
+import { Row } from "antd";
+import Movie from "../movies/components/MovieCard";
+import "./MyList.css";
+import { getBookmarks, clearBookmarks } from "../../shared/utils/userData";
+import { fetchMovieDetail } from "../movies/api";
 
 const MyList = () => {
-  const [userId, setUserId] = useState<string>('');
+  const [userId, setUserId] = useState<string>("");
   const [bookmarks, setBookmarks] = useState<any[]>([]);
   const [reviewed, setReviewed] = useState<any[]>([]);
-  const [activeTab, setActiveTab] = useState<'bookmarks' | 'reviewed'>('bookmarks');
+  const [activeTab, setActiveTab] = useState<"bookmarks" | "reviewed">(
+    "bookmarks"
+  );
 
   useEffect(() => {
-    const token = localStorage.getItem('token');
+    const token = localStorage.getItem("token");
     if (!token) return;
-    fetch('http://localhost:5001/users/protected', {
+    fetch("http://localhost:5001/users/protected", {
       headers: { Authorization: `Bearer ${token}` },
     })
       .then((r) => r.json())
@@ -24,7 +25,7 @@ const MyList = () => {
         setUserId(data.id);
         setBookmarks(getBookmarks(data.id));
         // Fetch my reviews from backend and hydrate with movie summaries
-        fetch('http://localhost:5001/reviews/user/me', {
+        fetch("http://localhost:5001/reviews/user/me", {
           headers: { Authorization: `Bearer ${token}` },
         })
           .then((r) => r.json())
@@ -41,7 +42,13 @@ const MyList = () => {
                     to: `/movie/${mv.id}?review=${encodeURIComponent(rv._id)}`,
                   };
                 } catch {
-                  return { id: rv.movieId, title: `영화 ${rv.movieId}`, to: `/movie/${rv.movieId}?review=${encodeURIComponent(rv._id)}` };
+                  return {
+                    id: rv.movieId,
+                    title: `영화 ${rv.movieId}`,
+                    to: `/movie/${rv.movieId}?review=${encodeURIComponent(
+                      rv._id
+                    )}`,
+                  };
                 }
               })
             );
@@ -52,38 +59,51 @@ const MyList = () => {
       .catch(() => {});
   }, []);
 
-  const list = activeTab === 'bookmarks' ? bookmarks : reviewed;
+  const list = activeTab === "bookmarks" ? bookmarks : reviewed;
 
   return (
     <div className="mylistContainer">
-      <Menu />
       <div className="mylistContent">
         <div className="mylistHeader">
-          <h2 style={{ margin:0 }}>Mylist</h2>
+          <h2 style={{ margin: 0 }}>Mylist</h2>
           <div className="actions">
-            {activeTab==='bookmarks' && (
-              <button onClick={()=>{ if(!userId) return; clearBookmarks(userId); setBookmarks([]); }}>북마크 비우기</button>
+            {activeTab === "bookmarks" && (
+              <button
+                onClick={() => {
+                  if (!userId) return;
+                  clearBookmarks(userId);
+                  setBookmarks([]);
+                }}
+              >
+                북마크 비우기
+              </button>
             )}
-            <button onClick={()=>window.scrollTo({top:0, behavior:'smooth'})}>맨위로</button>
+            <button
+              onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+            >
+              맨위로
+            </button>
           </div>
         </div>
         <div className="tabs">
           <button
-            className={activeTab === 'bookmarks' ? 'tab active' : 'tab'}
-            onClick={() => setActiveTab('bookmarks')}
+            className={activeTab === "bookmarks" ? "tab active" : "tab"}
+            onClick={() => setActiveTab("bookmarks")}
           >
             북마크 ({bookmarks.length})
           </button>
           <button
-            className={activeTab === 'reviewed' ? 'tab active' : 'tab'}
-            onClick={() => setActiveTab('reviewed')}
+            className={activeTab === "reviewed" ? "tab active" : "tab"}
+            onClick={() => setActiveTab("reviewed")}
           >
             리뷰 ({reviewed.length})
           </button>
         </div>
         <Row gutter={[32, 32]}>
           {list.length === 0 ? (
-            <div className="emptyBox">비어있어요. 마음에 드는 영화를 추가해보세요.</div>
+            <div className="emptyBox">
+              비어있어요. 마음에 드는 영화를 추가해보세요.
+            </div>
           ) : (
             list.map((m) => <Movie key={m.id} movieData={m} to={m.to} />)
           )}

--- a/src/features/profile/Profile.css
+++ b/src/features/profile/Profile.css
@@ -4,6 +4,8 @@
   box-sizing: border-box;
 }
 .profile-page {
+  display: flex;
+  align-items: center;
   min-height: 100vh;
   background: #000;
   color: #fff;

--- a/src/features/search/Search.tsx
+++ b/src/features/search/Search.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from "react";
-import Menu from "../../shared/components/Sidebar/Menu";
 import { Row } from "antd";
 import Movie from "../movies/components/MovieCard";
-import { useQuery } from '@tanstack/react-query';
-import { searchMovies } from '../movies/api';
+import { useQuery } from "@tanstack/react-query";
+import { searchMovies } from "../movies/api";
 
 const Search = () => {
   const [query, setQuery] = useState<string>("");
@@ -12,11 +11,14 @@ const Search = () => {
   const [error, setError] = useState<string>("");
 
   const { data, refetch, isFetching, isError } = useQuery({
-    queryKey: ['search', query],
+    queryKey: ["search", query],
     enabled: false,
     queryFn: () => searchMovies(query, 1),
   });
-  const doSearch = async () => { if (!query.trim()) return; await refetch(); };
+  const doSearch = async () => {
+    if (!query.trim()) return;
+    await refetch();
+  };
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") doSearch();
@@ -24,7 +26,6 @@ const Search = () => {
 
   return (
     <div className="mpgContainer">
-      <Menu />
       <div className="mpgTitle" style={{ width: "70%", margin: "1rem auto" }}>
         <div style={{ display: "flex", gap: 8, marginBottom: 16 }}>
           <input
@@ -41,7 +42,7 @@ const Search = () => {
         {isFetching && <p>검색 중...</p>}
         {isError && <p>검색 중 오류가 발생했습니다.</p>}
         <Row gutter={[32, 32]}>
-          {(data?.results || []).map((movie:any) => (
+          {(data?.results || []).map((movie: any) => (
             <Movie key={movie.id} movieData={movie} />
           ))}
         </Row>

--- a/src/index.css
+++ b/src/index.css
@@ -5,3 +5,8 @@ body {
   margin: 0;
   padding: 0;
 }
+
+#root {
+  min-height: 100vh;
+  background: #000; /* ensure no white shows through */
+}

--- a/src/pages/Main/Main.jsx
+++ b/src/pages/Main/Main.jsx
@@ -6,7 +6,6 @@ import "swiper/css";
 import "swiper/css/effect-coverflow";
 import "swiper/css/pagination";
 import "../Main/Main.css";
-import Menu from "shared/components/Sidebar/Menu";
 
 const Main = () => {
   const swiperRef = useRef(null);
@@ -127,7 +126,6 @@ const Main = () => {
 
   return (
     <>
-      <Menu />
       <div className="backgroundVideo">
         {currentVideoKey && (
           <>

--- a/src/shared/components/Sidebar/Menu.css
+++ b/src/shared/components/Sidebar/Menu.css
@@ -1,7 +1,8 @@
 .sidebarContainer {
   display: flex;
   width: 100%;
-  height: 30px;
+  height: 70px; /* match child heights to avoid visual gap */
+  background-color: #000; /* fully opaque to prevent hairline */
 }
 
 .title1 {
@@ -10,7 +11,7 @@
   height: 70px;
   text-align: left;
   align-items: center;
-  background-color: rgba(0, 0, 0, 0.979);
+  background-color: #000;
   overflow: hidden;
   gap: 24px; /* 왼쪽 아이템 간 간격을 일정하게 */
   padding-left: 16px;

--- a/src/shared/layouts/MainLayout.tsx
+++ b/src/shared/layouts/MainLayout.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { Outlet } from "react-router-dom";
+import Menu from "../../shared/components/Sidebar/Menu";
+
+const MainLayout: React.FC = () => {
+  return (
+    <div className="appShell">
+      <Menu />
+      <div className="appContent">
+        <Outlet />
+      </div>
+    </div>
+  );
+};
+
+export default MainLayout;


### PR DESCRIPTION
 ## 메뉴 컴포넌트를 공통 레이아웃으로 전환(+ 상단 헤어라인 이슈 해결)
  
  요약
  
  - 상단 메뉴를 페이지마다 직접 렌더링하던 방식에서, 공통 레이아웃(MainLayout)으로 전환했습니다.
  - 라우팅을 레이아웃 기반 중첩 라우팅으로 정리해 페이지 전환 시 메뉴가 재마운트되지 않도록 했습니다.
  - 헤더/본문 경계에 보이던 1px 흰 틈(헤어라인)을 제거했습니다.
  
  변경 사항
  
  - 레이아웃
      - src/shared/layouts/MainLayout.tsx: 공통 레이아웃(상단 Menu + <Outlet />) 추가/적용.
      - src/App.js: 앱 라우트(/main, /movies, /movie/:movieID, /search, /mypage, /mylist)를 <Route element={<MainLayout />}>로 래핑.
  - 페이지 정리
      - 각 페이지에서 직접 렌더 <Menu /> 제거(메뉴 중복 렌더 해소).
  - 스타일
      - src/shared/components/Sidebar/Menu.css: 헤더 높이 70px로 통일, 배경을 불투명 #000로 변경(투명도로 인한 흰 라인 방지).
      - src/index.css: #root { min-height: 100vh; background:#000; } 추가(기본 흰 바탕 노출 방지).
  
  변경 이유
  
  - 일관된 상단 네비게이션 유지 및 중복 제거.
  - 페이지 전환 시 헤더 재마운트/깜빡임 방지.
  - 레이아웃 기반으로 확장성(테마·헤더 상태 공유·전역 인터랙션) 확보.
  - 헤더/본문 경계의 렌더링 아티팩트(흰 틈) 해결.
  
  테스트 방법
  
  - 라우팅 확인: /main, /movies, /movie/550, /search, /mypage, /mylist 순회 시 헤더가 항상 유지되고 중복되지 않는지 확인.
  - 헤어라인 확인: 상단 경계에 흰색 1px 라인이 보이지 않는지 확인(다크 배경 유지).
  - 반응형/스크롤: 좁은 화면에서 메뉴 항목과 아바타 정렬, 스크롤 시 레이아웃 겹침 없음 확인.
  - 상세 페이지: 카드 링크 → 상세(/movie/:movieID) 이동 정상, 뒤로가기 시 상태/헤더 유지.
  
  영향 범위
  - 메뉴를 직접 가져다 쓰던 페이지는 레이아웃으로 대체됨. 상단 여백이 필요하면 개별 페이지 컨테이너에서 padding-top으로 조정.
  - 링크 경로는 그대로 유지(MovieCard → /movie/${id}), 라우트 정의는 절대 경로이므로 동작 동일.