### PR TITLE
feat(auth): 인증 모듈 기본 구성 추가 (토큰 유틸, useAuth, 가드, 공용 버튼/프롬프트)

### DIFF
--- a/src/shared/auth/RequireAuth.tsx
+++ b/src/shared/auth/RequireAuth.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { isAuthed } from './token';
+
+const RequireAuth: React.FC<{ children: React.ReactNode }>=({ children })=>{
+  const nav = useNavigate();
+  if (!isAuthed()) {
+    nav('/');
+    return null;
+  }
+  return <>{children}</>;
+};
+
+export default RequireAuth;
+

--- a/src/shared/auth/token.ts
+++ b/src/shared/auth/token.ts
@@ -1,0 +1,24 @@
+export function getToken(): string | null {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    return localStorage.getItem('token') || localStorage.getItem('accessToken');
+  } catch { return null; }
+}
+
+export function setToken(token: string) {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem('token', token);
+  } catch {}
+}
+
+export function clearToken() {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.removeItem('token');
+    localStorage.removeItem('accessToken');
+  } catch {}
+}
+
+export function isAuthed(): boolean { return !!getToken(); }
+

--- a/src/shared/auth/useAuth.ts
+++ b/src/shared/auth/useAuth.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import { getToken, clearToken } from './token';
+
+type User = { id: string; nick: string } | null;
+
+export function useAuth() {
+  const [user, setUser] = useState<User>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const t = getToken();
+        if (!t) { if (mounted) setUser(null); return; }
+        const { apiJson } = await import('shared/api/fetcher');
+        let me: any;
+        try { me = await apiJson('/auth/protected'); }
+        catch { me = await apiJson('/users/protected'); }
+        if (mounted) setUser({ id: me.id, nick: me.nickname || me.nick });
+      } catch { if (mounted) setUser(null); }
+      finally { if (mounted) setLoading(false); }
+    })();
+    return () => { mounted = false; };
+  }, []);
+
+  return {
+    user,
+    loading,
+    isAuthed: !!user,
+    logout: () => { clearToken(); setUser(null); },
+    setUser,
+  };
+}
+

--- a/src/shared/auth/useLoginRequiredPrompt.ts
+++ b/src/shared/auth/useLoginRequiredPrompt.ts
@@ -1,0 +1,16 @@
+import { useNavigate } from 'react-router-dom';
+import { isAuthed } from './token';
+
+export function useLoginRequiredPrompt(message = '로그인이 필요합니다.'){
+  const nav = useNavigate();
+  return function ensureAuthed<T>(action: ()=>T|Promise<T>) {
+    if (!isAuthed()) {
+      // eslint-disable-next-line no-alert
+      alert(message);
+      nav('/');
+      return;
+    }
+    return action();
+  }
+}
+

--- a/src/shared/components/RequireAuthButton.tsx
+++ b/src/shared/components/RequireAuthButton.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { useLoginRequiredPrompt } from 'shared/auth/useLoginRequiredPrompt';
+
+const RequireAuthButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement> & { onAuthed: ()=>void }>=({ onAuthed, children, ...rest })=>{
+  const ask = useLoginRequiredPrompt();
+  return <button {...rest} onClick={(e)=>{ e.preventDefault(); e.stopPropagation(); ask(onAuthed); }}>{children}</button>
+}
+
+export default RequireAuthButton;
+


### PR DESCRIPTION
- 요약:
      - 토큰 유틸 추가: get/set/clear/isAuthed
      - useAuth 훅: 초기 하이드레이션 + 1회 인증 확인(중복 호
  출 최소화)
      - RequireAuth(페이지 가드), useLoginRequiredPrompt(로그
  인 필요 공용 처리), RequireAuthButton(버튼 가드) 추가
      - 목적: 인증/토큰/로그인 필요 로직을 단일화해 중복 제거
  와 유지보수성 향상
  - 영향: 새로운 공통 모듈 추가만, 기존 화면은 영향 없음